### PR TITLE
Update + feat: Adds admin withdraw ticket retrieval [phamhminhkhoi]

### DIFF
--- a/src/main/java/com/sep490/gshop/business/WithdrawTicketBusiness.java
+++ b/src/main/java/com/sep490/gshop/business/WithdrawTicketBusiness.java
@@ -12,4 +12,8 @@ public interface WithdrawTicketBusiness extends BaseBusiness<WithdrawTicket>{
     List<WithdrawTicket> findByStatus(WithdrawStatus status);
     List<WithdrawTicket> findByWallet(UUID walletId);
     Page<WithdrawTicket> getAllByWalletId(UUID walletId, Pageable pageable);
+    Page<WithdrawTicket> findByStatus(WithdrawStatus status, Pageable pageable);
+    Page<WithdrawTicket> findAll(Pageable pageable);
+
+
 }

--- a/src/main/java/com/sep490/gshop/business/implement/WithdrawTicketImpl.java
+++ b/src/main/java/com/sep490/gshop/business/implement/WithdrawTicketImpl.java
@@ -30,4 +30,14 @@ public class WithdrawTicketImpl extends BaseBusinessImpl<WithdrawTicket, Withdra
     public Page<WithdrawTicket> getAllByWalletId(UUID walletId, Pageable pageable) {
         return repository.findByWallet_Id(walletId, pageable);
     }
+
+    @Override
+    public Page<WithdrawTicket> findByStatus(WithdrawStatus status, Pageable pageable) {
+        return repository.findByStatus(status, pageable);
+    }
+
+    @Override
+    public Page<WithdrawTicket> findAll(Pageable pageable) {
+        return repository.findAll(pageable);
+    }
 }

--- a/src/main/java/com/sep490/gshop/controller/WalletController.java
+++ b/src/main/java/com/sep490/gshop/controller/WalletController.java
@@ -1,6 +1,7 @@
 package com.sep490.gshop.controller;
 
 import com.sep490.gshop.common.constants.URLConstant;
+import com.sep490.gshop.common.enums.WithdrawStatus;
 import com.sep490.gshop.payload.dto.WithdrawTicketDTO;
 import com.sep490.gshop.payload.dto.WalletDTO;
 import com.sep490.gshop.payload.request.WalletRequest;
@@ -175,4 +176,17 @@ public class WalletController {
                             .build());
         }
     }
+
+    @GetMapping("/admin/withdraw-tickets")
+    public Page<WithdrawTicketDTO> getAllWithdrawTicketsForAdmin(
+            @RequestParam(required = false) WithdrawStatus status,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        log.info("getAllWithdrawTicketsForAdmin() - START | page: {}, size: {}, status: {}", page, size, status);
+        Page<WithdrawTicketDTO> result = walletService.getAllWithdrawTicketsForAdmin(page, size, status);
+        log.info("getAllWithdrawTicketsForAdmin() - END | returned {} records", result.getNumberOfElements());
+        return result;
+    }
+
 }

--- a/src/main/java/com/sep490/gshop/entity/Variant.java
+++ b/src/main/java/com/sep490/gshop/entity/Variant.java
@@ -11,6 +11,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class Variant extends BaseEntity {
     private String name;
-    private boolean isActive;
+    private Boolean isActive;
 
 }

--- a/src/main/java/com/sep490/gshop/repository/WithdrawTicketRepository.java
+++ b/src/main/java/com/sep490/gshop/repository/WithdrawTicketRepository.java
@@ -24,4 +24,9 @@ public interface WithdrawTicketRepository extends JpaRepository<WithdrawTicket, 
             "WHERE wt.createdAt BETWEEN :startDate AND :endDate " +
             "GROUP BY wt.status")
     List<PRStatus> countByStatus(Long startDate, Long endDate);
+
+    Page<WithdrawTicket> findByStatus(WithdrawStatus status, Pageable pageable);
+
+    Page<WithdrawTicket> findAll(Pageable pageable);
+
 }

--- a/src/main/java/com/sep490/gshop/service/WalletService.java
+++ b/src/main/java/com/sep490/gshop/service/WalletService.java
@@ -1,5 +1,6 @@
 package com.sep490.gshop.service;
 
+import com.sep490.gshop.common.enums.WithdrawStatus;
 import com.sep490.gshop.payload.dto.WalletDTO;
 import com.sep490.gshop.payload.dto.WithdrawTicketDTO;
 import com.sep490.gshop.payload.request.WalletRequest;
@@ -28,4 +29,6 @@ public interface WalletService {
     IPNResponse ipnCallback(HttpServletRequest request);
 
     Page<WithdrawTicketDTO> getWithdrawTicketsByCurrentUser(Pageable pageable);
+
+    Page<WithdrawTicketDTO> getAllWithdrawTicketsForAdmin(int page, int size, WithdrawStatus status);
 }

--- a/src/main/java/com/sep490/gshop/service/implement/WalletServiceImpl.java
+++ b/src/main/java/com/sep490/gshop/service/implement/WalletServiceImpl.java
@@ -24,6 +24,7 @@ import lombok.extern.log4j.Log4j2;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -532,6 +533,32 @@ public class WalletServiceImpl implements WalletService {
             throw e;
         }
     }
+
+    @Override
+    public Page<WithdrawTicketDTO> getAllWithdrawTicketsForAdmin(int page, int size, WithdrawStatus status) {
+        log.debug("getAllWithdrawTicketsForAdmin() WalletServiceImpl Start | status: {}", status);
+        try {
+            Page<WithdrawTicket> tickets;
+            Pageable pageable = PageRequest.of(page, size);
+            if (status == null) {
+
+                tickets = withdrawTicketBusiness.findAll(pageable);
+            } else {
+                tickets = withdrawTicketBusiness.findByStatus(status, pageable);
+            }
+
+            Page<WithdrawTicketDTO> ticketsDTO = tickets.map(ticket ->
+                    modelMapper.map(ticket, WithdrawTicketDTO.class)
+            );
+            log.debug("getAllWithdrawTicketsForAdmin() WalletServiceImpl End | found {} tickets", ticketsDTO.getSize());
+            return ticketsDTO;
+        } catch (Exception e) {
+            log.error("getAllWithdrawTicketsForAdmin() WalletServiceImpl Exception | message: {}", e.getMessage());
+            throw e;
+        }
+    }
+
+
 
 
 }


### PR DESCRIPTION
Implements functionality for admins to retrieve withdraw tickets,
allowing filtering by status and pagination. This enhancement
provides administrators with better tools for managing and
monitoring withdraw requests.

Also, normalizes the `isActive` property of the Variant entity to be
Boolean instead of boolean.
