### PR TITLE
hotfix: Corrects currency code for Vietnamese Dong [phamhminhkhoi]

### DIFF
--- a/src/main/java/com/sep490/gshop/service/implement/QuotationServiceImpl.java
+++ b/src/main/java/com/sep490/gshop/service/implement/QuotationServiceImpl.java
@@ -370,7 +370,7 @@ public class QuotationServiceImpl implements QuotationService {
                     BigDecimal converted = calculationUtil.convertToVND(BigDecimal.valueOf(value), feeCurrency);
                     otherFeesVND += converted.doubleValue();
                     feeToVND.setAmount(CalculationUtil.roundToNearestThousand(converted.doubleValue()));
-                    feeToVND.setCurrency("VNĐ");
+                    feeToVND.setCurrency("VND");
                     feeToVND.setFeeName(fee.getFeeName());
                     feeEntities.add(feeToVND);
                 } else {


### PR DESCRIPTION
Updates the currency code for Vietnamese Dong from "VNĐ" to "VND"
to comply with the ISO 4217 standard.
