### PR TITLE
Adds paginated root HS code tree endpoint

### DIFF
--- a/src/main/java/com/sep490/gshop/business/HsCodeBusiness.java
+++ b/src/main/java/com/sep490/gshop/business/HsCodeBusiness.java
@@ -6,4 +6,5 @@ import org.springframework.data.domain.Pageable;
 
 public interface HsCodeBusiness extends BaseBusinessGeneric<HsCode, String>{
     Page<HsCode> searchByKeyword(String hsCode, String description, Pageable pageable);
+    Page<HsCode> getAll(Pageable pageable);
 }

--- a/src/main/java/com/sep490/gshop/business/implement/HsCodeBusinessImpl.java
+++ b/src/main/java/com/sep490/gshop/business/implement/HsCodeBusinessImpl.java
@@ -18,4 +18,9 @@ public class HsCodeBusinessImpl extends BaseBusinessGenericImpl<HsCode,String, H
     public Page<HsCode> searchByKeyword(String hsCode, String description, Pageable pageable) {
         return repository.searchByHsCodeAndDescription(hsCode, description, pageable);
     }
+
+    @Override
+    public Page<HsCode> getAll(Pageable pageable) {
+        return repository.getAll(pageable);
+    }
 }

--- a/src/main/java/com/sep490/gshop/controller/HsCodeController.java
+++ b/src/main/java/com/sep490/gshop/controller/HsCodeController.java
@@ -3,6 +3,7 @@ package com.sep490.gshop.controller;
 import com.sep490.gshop.common.constants.URLConstant;
 import com.sep490.gshop.payload.dto.HsCodeDTO;
 import com.sep490.gshop.payload.dto.HsCodeSearchDTO;
+import com.sep490.gshop.payload.dto.HsTreeNodeDTO;
 import com.sep490.gshop.payload.request.HsCodeRequest;
 import com.sep490.gshop.payload.response.MessageResponse;
 import com.sep490.gshop.service.HsCodeService;
@@ -10,6 +11,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -72,5 +75,13 @@ public class HsCodeController {
         log.info("deleteHsCode() - End | hsCode: {}, success: {}", hsCode, response.isSuccess());
         HttpStatus status = response.isSuccess() ? HttpStatus.OK : HttpStatus.BAD_REQUEST;
         return ResponseEntity.status(status).body(response);
+    }
+
+    @GetMapping("/tree/root")
+    public Page<HsTreeNodeDTO> getRootNodesPaged(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return hsCodeService.getRootNodesPaged(pageable);
     }
 }

--- a/src/main/java/com/sep490/gshop/payload/dto/HsTreeNodeDTO.java
+++ b/src/main/java/com/sep490/gshop/payload/dto/HsTreeNodeDTO.java
@@ -1,0 +1,25 @@
+package com.sep490.gshop.payload.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class HsTreeNodeDTO {
+    private String code;             // hsCode
+    private String description;
+    private Integer level;
+    private String parentCode;       // mã cha để gán cây
+    private List<HsTreeNodeDTO> children;
+    public void addChild(HsTreeNodeDTO c) {
+        if (children == null) children = new ArrayList<>();
+        children.add(c);
+    }
+}

--- a/src/main/java/com/sep490/gshop/repository/HsCodeRepository.java
+++ b/src/main/java/com/sep490/gshop/repository/HsCodeRepository.java
@@ -43,6 +43,8 @@ WHERE
             Pageable pageable
     );
 
+    @Query("SELECT h FROM HsCode h WHERE LENGTH(h.hsCode) = 2 AND (h.parentCode IS NULL OR h.parentCode = '') ORDER BY h.hsCode")
+    Page<HsCode> getAll(Pageable pageable);
 
 
 }

--- a/src/main/java/com/sep490/gshop/service/HsCodeService.java
+++ b/src/main/java/com/sep490/gshop/service/HsCodeService.java
@@ -2,6 +2,7 @@ package com.sep490.gshop.service;
 
 import com.sep490.gshop.payload.dto.HsCodeDTO;
 import com.sep490.gshop.payload.dto.HsCodeSearchDTO;
+import com.sep490.gshop.payload.dto.HsTreeNodeDTO;
 import com.sep490.gshop.payload.request.HsCodeRequest;
 import com.sep490.gshop.payload.response.MessageResponse;
 import org.springframework.data.domain.Page;
@@ -14,5 +15,7 @@ public interface HsCodeService {
     HsCodeDTO createHsCodeIncludeTaxes(HsCodeRequest hsCodeRequest);
     HsCodeDTO getByHsCode(String hsCode);
     MessageResponse deleteHsCode(String hsCode);
-    //Không có update cho hsCode
+
+
+    Page<HsTreeNodeDTO> getRootNodesPaged(Pageable pageable);
 }


### PR DESCRIPTION
This pull request introduces a new endpoint to retrieve a paginated list of root HS codes as a tree structure.

- Exposes a `/tree/root` endpoint for retrieving the HS code tree root nodes.
- Introduces `HsTreeNodeDTO` to represent the tree structure.
- Implements pagination for efficient retrieval of root nodes.