### PR TITLE
fix: Removes role-based access control for variants [phamhminhkhoi]

### DIFF
--- a/src/main/java/com/sep490/gshop/controller/VariantController.java
+++ b/src/main/java/com/sep490/gshop/controller/VariantController.java
@@ -30,7 +30,7 @@ public class VariantController {
     }
 
     @GetMapping
-    @PreAuthorize("hasRole('BUSINESS_MANAGER')")
+
     public ResponseEntity<List<VariantDTO>> getAllVariants() {
         log.info("getAllVariants() - Start");
         List<VariantDTO> variants = variantService.getAllVariants();


### PR DESCRIPTION
Removes the `@PreAuthorize` annotation from the `getAllVariants()` method.
This simplifies access to variant data, removing the need for 'BUSINESS_MANAGER' role.
