### PR TITLE
fix: Improves HSCode and TaxRate CSV import handling [phamhminhkhoi]

### DIFF
--- a/src/main/java/com/sep490/gshop/business/HsCodeBusiness.java
+++ b/src/main/java/com/sep490/gshop/business/HsCodeBusiness.java
@@ -11,4 +11,5 @@ public interface HsCodeBusiness extends BaseBusinessGeneric<HsCode, String>{
     Page<HsCode> getAll(Pageable pageable);
     Page<HsCode> searchByHsCodeAndDescriptionForRoots(String hsCodeSearch, String descSearch,Pageable pageable);
 
+    boolean existByHsCode(String hsCode);
 }

--- a/src/main/java/com/sep490/gshop/business/implement/HsCodeBusinessImpl.java
+++ b/src/main/java/com/sep490/gshop/business/implement/HsCodeBusinessImpl.java
@@ -7,8 +7,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 @Component
 public class HsCodeBusinessImpl extends BaseBusinessGenericImpl<HsCode,String, HsCodeRepository> implements HsCodeBusiness {
 
@@ -27,6 +25,9 @@ public class HsCodeBusinessImpl extends BaseBusinessGenericImpl<HsCode,String, H
     public Page<HsCode> searchByHsCodeAndDescriptionForRoots(String hsCodeSearch, String descSearch, Pageable pageable) {
         return repository.searchByHsCodeAndDescriptionForRoots(hsCodeSearch, descSearch, pageable);
     }
-
+    @Override
+    public boolean existByHsCode(String hsCode){
+        return repository.existsByHsCode(hsCode);
+    }
 
 }

--- a/src/main/java/com/sep490/gshop/repository/HsCodeRepository.java
+++ b/src/main/java/com/sep490/gshop/repository/HsCodeRepository.java
@@ -47,7 +47,7 @@ AND (COALESCE(:desc, '') = '' OR to_tsvector('simple', unaccent(description)) @@
             Pageable pageable
     );
 
-
+    boolean existsByHsCode(String hsCode);
 
 
 


### PR DESCRIPTION
Enhances the HSCode and TaxRate CSV import processes to detect and report duplicate entries.

This change prevents the re-import of existing data, improving data integrity and providing informative feedback to the user about the import results, including the number of imported rows and any duplicates found. It avoids displaying the stack trace error to the user.
